### PR TITLE
Remove noarch: python

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,8 +10,16 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_python2.7:
+        CONFIG: linux_python2.7
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_python3.6:
+        CONFIG: linux_python3.6
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_python3.7:
+        CONFIG: linux_python3.7
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,82 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-10.13
+  timeoutInMinutes: 360
+  strategy:
+    maxParallel: 8
+    matrix:
+      osx_python2.7:
+        CONFIG: osx_python2.7
+        UPLOAD_PACKAGES: True
+      osx_python3.6:
+        CONFIG: osx_python3.6
+        UPLOAD_PACKAGES: True
+      osx_python3.7:
+        CONFIG: osx_python3.7
+        UPLOAD_PACKAGES: True
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      echo "Fast Finish"
+      
+
+  - script: |
+      echo "Removing homebrew from Azure to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+    displayName: Remove homebrew
+
+  - bash: |
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
+    displayName: Add conda to PATH
+
+  - script: |
+      source activate base
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+    displayName: 'Add conda-forge-ci-setup=2'
+
+  - script: |
+      source activate base
+      echo "Configuring conda."
+
+      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      export CI=azure
+      source run_conda_forge_build_setup
+      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+    env: {
+      OSX_FORCE_SDK_DOWNLOAD: "1"
+    }
+    displayName: Configure conda and conda-build
+
+  - script: |
+      source activate base
+      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Mangle compiler
+
+  - script: |
+      source activate base
+      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Generate build number clobber file
+
+  - script: |
+      source activate base
+      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    displayName: Build recipe
+
+  - script: |
+      source activate base
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Upload package
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -4,3 +4,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/README.md
+++ b/README.md
@@ -15,11 +15,77 @@ Current build status
 ====================
 
 
-<table><tr><td>All platforms:</td>
+<table>
+    
+  <tr>
+    <td>Azure</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master">
-      </a>
+      <details>
+        <summary>
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master">
+          </a>
+        </summary>
+        <table>
+          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
+          <tbody><tr>
+              <td>linux_python2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6407&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/idq-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
+    </td>
+  </tr>
+  <tr>
+    <td>Windows</td>
+    <td>
+      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
+    </td>
+  </tr>
+  <tr>
+    <td>Linux_ppc64le</td>
+    <td>
+      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,54 +3,79 @@
 {% set sha256 = "d0754fd0f920b5ae347be419d583a51e18ba9428edac31dc197b72b0b9c964ce" %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
 
 source:
-  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
 
 build:
-  number: 1
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  number: 2
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [win]
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - setuptools
 
   run:
-    - python
-    - numpy >=1.7.1
-    - scipy
+    - dqsegdb
     - h5py >=2.3.0
-    - matplotlib >=1.2.0
-    - python-lal
-    - python-lalframe
     - lscsoft-glue
     - ligo-common
     - ligo-segments
     - ligo-scald
     - libframe
-    - dqsegdb
-    - python-ldas-tools-framecpp
+    - matplotlib-base >=1.2.0
+    - numpy >=1.7.1
+    - python
     - python-confluent-kafka >=0.11.4
+    - python-lal
+    - python-lalframe
+    - python-ldas-tools-framecpp
+    - python-ligo-lw
     - scikit-learn >=0.18.2
+    - scipy
 
 test:
   imports:
     - idq
+  commands:
+    - idq-batch --help
+    - idq-calibrate --help
+    - idq-condor_batch --help
+    - idq-condor_train --help
+    - idq-condor_evaluate --help
+    - idq-condor_calibrate --help
+    - idq-condor_timeseries --help
+    - idq-check_config --help
+    - idq-evaluate --help
+    #- idq-kwm2hdf5 --help  <-- requires gstlal (not a user script)
+    - idq-kwm2kws --help
+    - idq-monitor --help
+    - idq-report --help
+    - idq-simtimeseries --help
+    - idq-stream --help
+    - idq-streaming_train --help
+    - idq-streaming_evaluate --help
+    - idq-streaming_calibrate --help
+    - idq-streaming_timeseries --help
+    - idq-streaming_report --help
+    - idq-target-times --help
+    - idq-timeseries --help
+    - idq-train --help
 
 about:
-  home: https://git.ligo.org/reed.essick/iDQ
-  license: MIT
-  license_family: MIT
-  license_file: LICENSE
-  doc_url: https://docs.ligo.org/reed.essick/iDQ
-  dev_url: https://git.ligo.org/reed.essick/iDQ
-  summary: a low-latency statistical data quality pipeline for glitch detection
+  home: "https://git.ligo.org/reed.essick/iDQ"
+  license: "MIT"
+  license_family: "MIT"
+  license_file: "LICENSE"
+  doc_url: "https://docs.ligo.org/reed.essick/iDQ"
+  dev_url: "https://git.ligo.org/reed.essick/iDQ"
+  summary: "a low-latency statistical data quality pipeline for glitch detection"
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This package currently isn't `noarch: python`-appropriate, so I have removed it, as well as adding `<> --help` `test/commands` for each of the scripts.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
